### PR TITLE
Fix newline in Supabase utils

### DIFF
--- a/utils/supabase/client.ts
+++ b/utils/supabase/client.ts
@@ -3,5 +3,5 @@ import { createBrowserClient } from "@supabase/ssr";
 export const createClient = () =>
   createBrowserClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-  ); 
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+  )

--- a/utils/supabase/server.ts
+++ b/utils/supabase/server.ts
@@ -24,5 +24,5 @@ export const createClient = async () => {
         },
       },
     }
-  );
-}; 
+  )
+}


### PR DESCRIPTION
## Summary
- fix trailing spaces and missing newline at end of `utils/supabase` utilities

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846c78ca9308332bd850951d3712c31