### PR TITLE
Enable related questions after manual replies

### DIFF
--- a/lib/streaming/create-manual-tool-stream.ts
+++ b/lib/streaming/create-manual-tool-stream.ts
@@ -70,7 +70,7 @@ export function createManualToolStreamResponse(config: BaseStreamConfig) {
               chatId,
               dataStream,
               userId,
-              skipRelatedQuestions: true,
+              skipRelatedQuestions: false,
               annotations
             })
           },


### PR DESCRIPTION
## Summary
- manual models now include related questions on completion

## Testing
- `bun x next lint`

------
https://chatgpt.com/codex/tasks/task_e_6846cbc61dc88332a17fd12df3a8ae2f